### PR TITLE
InvalidUserNameOrPassword

### DIFF
--- a/MSOLSpray.ps1
+++ b/MSOLSpray.ps1
@@ -111,9 +111,9 @@
                 # my modifications here
             If($RespErr -match "AADSTS50126")
                 {
+                #Write the accounts that result in the AADSTS error code AADSTS50126 (InvalidUserNameOrPassword) to both the screen as well as to the log file when using the -Outfile parameter.
                 Write-Host -ForegroundColor "yellow" "[*] WARNING! Valid user, but invalid password for $username."
                 $fullresults += "Valid user, but invalid password : $username"
-                #continue
                 }
 
                 # Invalid Tenant Response


### PR DESCRIPTION
Updated to log the accounts with the AADSTS error code AADSTS50126 (InvalidUserNameOrPassword) to both the screen as well as to the log when using the -Outfile parameter. This allows subsequent password sprays to run much quicker as you can eliminate the invalid accounts from the list of accounts to spray