### PR TITLE
Add trailing newline to status reporting

### DIFF
--- a/MSOLSpray.ps1
+++ b/MSOLSpray.ps1
@@ -202,4 +202,5 @@
         Write-Output "Results have been written to $OutFile."
         }
     }
+    Write-Host ""
 }


### PR DESCRIPTION
When spraying, MSOLSpray uses a `Write-Host` without a trailing LF to show incremental progress `N of NNN users tested`. Then the spray completes, there it no additional LF, so the prompt often looks like this:

```
PS /home/josh> Invoke-MSOLSpray -UserList ./userlist.txt -Password "Solarwinds123"
[*] There are 1 total users to spray.
[*] Now spraying Microsoft Online.
[*] Current date and time: 04/11/2022 10:53:45
PS /home/josh> sted
```

The _sted_ is the trailing output of the status indicator. This patch adds a newline to the end of the main `ForEach` loop. The output at the end of MSOLSpray will look like this:

```
PS /home/josh> Invoke-MSOLSpray -UserList ./userlist.txt -Password "Solarwinds123"
[*] There are 1 total users to spray.
[*] Now spraying Microsoft Online.
[*] Current date and time: 04/11/2022 10:53:45
200 of 200 users tested
PS /home/josh> 
```

NBD, just a minor nicety. Thanks!