### PR TITLE
Add TenantID Parameter

### DIFF
--- a/MSOLSpray.ps1
+++ b/MSOLSpray.ps1
@@ -68,7 +68,12 @@ function Invoke-MSOLSpray{
     [string]
     $URL = "https://login.microsoft.com",
 
+    # Specify a target tenant ID (used to force authentication attempts against a specific tenant for B2B users)
     [Parameter(Position = 4, Mandatory = $False)]
+    [string]
+    $TenantId = "common",
+
+    [Parameter(Position = 5, Mandatory = $False)]
     [switch]
     $Force
   )
@@ -96,7 +101,7 @@ function Invoke-MSOLSpray{
         # Setting up the web request
         $BodyParams = @{'resource' = 'https://graph.windows.net'; 'client_id' = '1b730954-1685-4b74-9bfd-dac224a7b894' ; 'client_info' = '1' ; 'grant_type' = 'password' ; 'username' = $username ; 'password' = $password ; 'scope' = 'openid'}
         $PostHeaders = @{'Accept' = 'application/json'; 'Content-Type' =  'application/x-www-form-urlencoded'}
-        $webrequest = Invoke-WebRequest $URL/common/oauth2/token -Method Post -Headers $PostHeaders -Body $BodyParams -ErrorVariable RespErr 
+        $webrequest = Invoke-WebRequest $URL/$TenantId/oauth2/token -Method Post -Headers $PostHeaders -Body $BodyParams -ErrorVariable RespErr 
 
         # If we get a 200 response code it's a valid cred
         If ($webrequest.StatusCode -eq "200"){


### PR DESCRIPTION
Allow the user to specify a Tenant ID to target. This can be used to force authentication against a specific tenant, e.g. spray external B2B users against the external tenant to cause authentication log events against the B2B tenancy.

The base URL can be modified to replace "common" with the Tenant ID of the target tenancy with no other modifications to the request.

This can be used to check whether an account exists in the external tenancy, determine if there are any conditional access policy or MFA differences and to check the efficacy of the external tenant's password protection settings.